### PR TITLE
feat: allow pinning study items

### DIFF
--- a/style.css
+++ b/style.css
@@ -153,6 +153,28 @@ textarea {
     border-radius: 6px;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.1);
     cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+#review-list button {
+    margin-left: 0.3rem;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#review-list .pin-btn {
+    background: #ddd;
+    color: #333;
+}
+
+#review-list .pin-btn.pinned {
+    background: #f1c40f;
+    color: #333;
 }
 
 #review-card-box {


### PR DESCRIPTION
## Summary
- allow cards in Study list to be pinned for quick access
- add pin button and styles, sort pinned items to top
- preserve pin state in storage and on import

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68940553d170832094d9864941e874f0