### PR TITLE
fix: use dynamic redirect URL for email confirmation

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -81,9 +81,16 @@ async function register(email, password) {
         }
 
         console.log('Calling supabaseClient.auth.signUp...');
+        // Use current page URL as the redirect so the confirmation email
+        // links back to wherever the app is actually hosted (not localhost)
+        const redirectUrl = window.location.origin + window.location.pathname;
+        console.log('Email redirect URL:', redirectUrl);
         const { data, error } = await supabaseClient.auth.signUp({
             email: email,
-            password: password
+            password: password,
+            options: {
+                emailRedirectTo: redirectUrl
+            }
         });
 
         console.log('signUp response - data:', data, 'error:', error);


### PR DESCRIPTION
The Supabase signUp call now includes emailRedirectTo set to window.location.origin + pathname, so the confirmation email links back to wherever the app is actually hosted instead of defaulting to localhost:3000 from the Supabase dashboard config.

https://claude.ai/code/session_01P8LqpUqLsxYYVN4TAfvuJK