### PR TITLE
fix: auto-login after registration when email confirmation is disabled

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,9 +122,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             console.log('Register result:', result);
 
             if (result.success) {
+                registerForm.reset();
+
+                // If Supabase returned a session, the user is already confirmed
+                // (email confirmation is disabled) — log them in directly
+                if (result.data && result.data.session) {
+                    console.log('Session returned — email confirmation not required, logging in');
+                    showApp(result.data.session.user);
+                    return;
+                }
+
+                // Otherwise email confirmation is required
                 successEl.textContent = 'Registration successful! Please check your email to verify your account, then login.';
                 successEl.classList.remove('hidden');
-                registerForm.reset();
 
                 // Auto-switch to login after 3 seconds
                 setTimeout(() => {


### PR DESCRIPTION
When Supabase returns a session in the signUp response, the user is already confirmed (email confirmation is disabled in the project). Instead of showing "check your email", log the user in directly.

https://claude.ai/code/session_01P8LqpUqLsxYYVN4TAfvuJK