### PR TITLE
Add !important flag to hidden class display rules

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ main section {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 
@@ -297,7 +297,7 @@ audio::-webkit-media-controls-current-time-display {
 }
 
 button.hidden {
-    display: none;
+    display: none !important;
 }
 
 /* Secondary action buttons */


### PR DESCRIPTION
## Summary
Added the `!important` flag to CSS rules that hide elements using the `.hidden` class to ensure these styles cannot be overridden by other CSS rules with lower specificity.

## Changes
- Updated `.hidden` class rule to use `display: none !important;`
- Updated `button.hidden` class rule to use `display: none !important;`

## Details
This change ensures that elements marked with the `.hidden` class will consistently remain hidden regardless of other CSS rules that might attempt to override the display property. This is particularly important for the `button.hidden` rule to prevent accidental visibility of hidden buttons through cascading styles or inline styles with lower specificity.

https://claude.ai/code/session_01XSuyrLozvFKHCACG5At6XT